### PR TITLE
Fix keyvaluestore.New function return type

### DIFF
--- a/cmd/blinkyd/main.go
+++ b/cmd/blinkyd/main.go
@@ -120,7 +120,7 @@ func registerHTTPHandlers(repoPaths []string, dbPath, gpgDir, apiUname, apiPassw
 	apiAuth := httpbasicauth.New(apiUname, apiPasswd)
 
 	apiRouter := mux.NewRouter()
-	apiUnstable := apiunstable.New(&ds, &apiAuth, correlateRepoNames(repoPaths), gpgDir, requireSignedPkgs, signDB)
+	apiUnstable := apiunstable.New(ds, &apiAuth, correlateRepoNames(repoPaths), gpgDir, requireSignedPkgs, signDB)
 	apiUnstable.Register(apiRouter.PathPrefix("/api/unstable/").Subrouter())
 
 	http.Handle("/api/unstable/", apiRouter)

--- a/keyvaluestore/kv.go
+++ b/keyvaluestore/kv.go
@@ -6,13 +6,13 @@ import (
 	"github.com/dgraph-io/badger/v3"
 )
 
-func New(dbDirPath string) (BadgerAdapter, error) {
+func New(dbDirPath string) (*BadgerAdapter, error) {
 	db, err := badger.Open(badger.DefaultOptions(dbDirPath))
 	if err != nil {
-		return BadgerAdapter{}, err
+		return nil, err
 	}
 
-	return BadgerAdapter{db: db}, nil
+	return &BadgerAdapter{db: db}, nil
 }
 
 type BadgerAdapter struct { // implements: github.com/BrenekH/blinky.PackageNameToFileProvider


### PR DESCRIPTION
Just a small change, but the type that implements PackageNameToFileProvider is *BadgerAdapter, so it should return that.